### PR TITLE
luci-app-cgminer: fix miner status page on iOS

### DIFF
--- a/applications/luci-app-cgminer/luasrc/view/hashrate.htm
+++ b/applications/luci-app-cgminer/luasrc/view/hashrate.htm
@@ -1012,7 +1012,7 @@ function waitForSvg(id, callback)
             svgDoc = svg.getSVGDocument
                 ? svg.getSVGDocument() : svg.contentDocument;
         } catch(e) {
-            svgDoc = document.embeds[id].getSVGDocument();
+            svgDoc = document.embeds[id].firstElementChild;
         }
 	if (!svgDoc) {
 		console.log('svg not there, waiting...');

--- a/applications/luci-app-cgminer/luasrc/view/hashrate.htm
+++ b/applications/luci-app-cgminer/luasrc/view/hashrate.htm
@@ -14,16 +14,15 @@ a { text-decoration: none; }
 table.stats { width: auto; margin-top: 1em; } //margin-left: auto; margin-right: auto; }
 	</style>
 
-<h1>Miner Status<span id="what"</span></h1>
+<h1>Miner Status<span id="what"></span></h1>
 <p>API connection status: <span id="status">Not connected</span></p>
 
 <embed id="hashrate-svg" style="width:100%; height:300px; border:1px solid #000000; background-color:#FFFFFF" src="/luci-static/resources/miner_graph.svg">
 
-<table class="stats" id="chains-table" />
-<table class="stats" id="pools-table" />
-<table class="stats" id="summary-table" />
-<table class="stats" id="fans-table" />
-<table />
+<table class="stats" id="chains-table"></table>
+<table class="stats" id="pools-table"></table>
+<table class="stats" id="summary-table"></table>
+<table class="stats" id="fans-table"></table>
 
 <script type="text/javascript">//<![CDATA[
 


### PR DESCRIPTION
Mobile Safari doesn't support getSVGDocument() on embeds which leads to entire js crashing on iOS and empty miner status page.
Changing getSVGDocument() call to firstElementChild fixes this problem without breaking compatibility with other browsers.

Status page on iPad Air 2 running iOS 12.1.1 before changes:
[![2vUL.th.png](https://corgi.party/p/2vUL.th.png)](https://corgi.party/p/2vUL.png)

Status page on iPad Air 2 running iOS 12.1.1 after changes:
[![2reg.th.png](https://corgi.party/p/2reg.th.png)](https://corgi.party/p/2reg.png)